### PR TITLE
Fix go.mod again

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The configuration defines several parameters that can be used by the library.  T
 package main
 
 import (
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/credentials"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/credentials"
 )
 
 var config = sfdc.Configuration{

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -3,7 +3,7 @@ package bulk
 import (
 	"errors"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 const bulk2Endpoint = "/jobs/ingest"

--- a/bulk/bulk_test.go
+++ b/bulk/bulk_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 func TestNewResource(t *testing.T) {

--- a/bulk/job.go
+++ b/bulk/job.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // JobType is the bulk job type.

--- a/bulk/job_test.go
+++ b/bulk/job_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 func TestJob_formatOptions(t *testing.T) {

--- a/bulk/jobs.go
+++ b/bulk/jobs.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // Parameters to query all of the bulk jobs.

--- a/bulk/jobs_test.go
+++ b/bulk/jobs_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 func TestJobs_do(t *testing.T) {

--- a/composite/batch/batch.go
+++ b/composite/batch/batch.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // Subrequester provides the composite batch API requests.

--- a/composite/batch/batch_test.go
+++ b/composite/batch/batch_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 type mockSubrequester struct {

--- a/composite/composite.go
+++ b/composite/composite.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // Subrequester provides the composite API requests.  The

--- a/composite/composite_test.go
+++ b/composite/composite_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 type mockSubrequester struct {

--- a/config.go
+++ b/config.go
@@ -3,7 +3,7 @@ package sfdc
 import (
 	"net/http"
 
-	"github.com/namely/go-sfdc/credentials"
+	"github.com/namely/go-sfdc/v3/credentials"
 )
 
 // Configuration is the structure for goforce sessions.

--- a/session/session.go
+++ b/session/session.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/credentials"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/credentials"
 )
 
 // Session is the authentication response.  This is used to generate the

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/credentials"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/credentials"
 )
 
 func TestPasswordSessionRequest(t *testing.T) {

--- a/sobject/collections/collections.go
+++ b/sobject/collections/collections.go
@@ -11,9 +11,9 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 const (

--- a/sobject/collections/collections_test.go
+++ b/sobject/collections/collections_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 func Test_collection_send(t *testing.T) {

--- a/sobject/collections/delete.go
+++ b/sobject/collections/delete.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 // DeleteValue is the return value from the

--- a/sobject/collections/delete_test.go
+++ b/sobject/collections/delete_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 func TestDelete_values(t *testing.T) {

--- a/sobject/collections/insert.go
+++ b/sobject/collections/insert.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"net/http"
 
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 type insert struct {

--- a/sobject/collections/insert_test.go
+++ b/sobject/collections/insert_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 type mockInserter struct {

--- a/sobject/collections/query.go
+++ b/sobject/collections/query.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 type collectionQueryPayload struct {

--- a/sobject/collections/query_test.go
+++ b/sobject/collections/query_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 type mockQuery struct {

--- a/sobject/collections/update.go
+++ b/sobject/collections/update.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"net/http"
 
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 // UpdateValue is the return value from the

--- a/sobject/collections/update_test.go
+++ b/sobject/collections/update_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 type mockUpdater struct {

--- a/sobject/describe.go
+++ b/sobject/describe.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // DescribeValue is a structure that is returned from the from the Salesforce

--- a/sobject/describe_test.go
+++ b/sobject/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 func Test_describe_Describe(t *testing.T) {

--- a/sobject/dml.go
+++ b/sobject/dml.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // InsertValue is the value that is returned when a

--- a/sobject/dml_test.go
+++ b/sobject/dml_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 type mockInserter struct {

--- a/sobject/framework.go
+++ b/sobject/framework.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // ObjectURLs is the URL for the SObject metadata.

--- a/sobject/framework_test.go
+++ b/sobject/framework_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 func TestSalesforceAPI_Metadata(t *testing.T) {

--- a/sobject/metadata.go
+++ b/sobject/metadata.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // MetadataValue is the response from the SObject metadata API.

--- a/sobject/metadata_test.go
+++ b/sobject/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 func Test_metadata_Metadata(t *testing.T) {

--- a/sobject/query.go
+++ b/sobject/query.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // Querier is the interface used to query a SObject from

--- a/sobject/query_test.go
+++ b/sobject/query_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 type mockQuery struct {

--- a/sobject/tree/builder.go
+++ b/sobject/tree/builder.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/namely/go-sfdc/sobject"
+	"github.com/namely/go-sfdc/v3/sobject"
 )
 
 // Builder is the SObject Tree builder for the

--- a/sobject/tree/tree.go
+++ b/sobject/tree/tree.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // Inserter is used to define the SObject and it's records for the

--- a/sobject/tree/tree_test.go
+++ b/sobject/tree/tree_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 type mockInserter struct {

--- a/soql/query.go
+++ b/soql/query.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/namely/go-sfdc"
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 // Resource is the structure for the Salesforce

--- a/soql/query_test.go
+++ b/soql/query_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/namely/go-sfdc/session"
+	"github.com/namely/go-sfdc/v3/session"
 )
 
 type mockQuerier struct {

--- a/soql/record.go
+++ b/soql/record.go
@@ -1,6 +1,6 @@
 package soql
 
-import "github.com/namely/go-sfdc"
+import "github.com/namely/go-sfdc/v3"
 
 // QueryRecord is the result of the SOQL record.  If
 // the query statement contains an inner query, there

--- a/soql/record_test.go
+++ b/soql/record_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/namely/go-sfdc"
+	"github.com/namely/go-sfdc/v3"
 )
 
 func testQueryRecord(jsonMap map[string]interface{}) *sfdc.Record {


### PR DESCRIPTION
https://github.com/golang/go/issues/35732
and
https://golang.org/cmd/go/#hdr-Module_compatibility_and_semantic_versioning

![image](https://user-images.githubusercontent.com/32271530/84677687-c0be9900-af37-11ea-8293-2447d85f06c8.png)

tests:
```
make test-local
go test `go list ./... | grep -v '/mocks' | grep -v '/gen'` -cover -count=1
go: finding module for package github.com/namely/go-sfdc
go: finding module for package github.com/namely/go-sfdc/session
go: finding module for package github.com/namely/go-sfdc/credentials
go: finding module for package github.com/namely/go-sfdc/sobject
go: finding module for package github.com/namely/go-sfdc
go: finding module for package github.com/namely/go-sfdc/session
go: finding module for package github.com/namely/go-sfdc/credentials
go: finding module for package github.com/namely/go-sfdc/sobject
config.go:6:2: no matching versions for query "latest"
bulk/job.go:14:2: no matching versions for query "latest"
bulk/bulk.go:6:2: no matching versions for query "latest"
sobject/collections/collections.go:16:2: no matching versions for query "latest"
make: *** [test-local] Error 1
```