### PR TITLE
Add subrequester implementation for fetching Limit information.

### DIFF
--- a/bulk/mock_session_formatter.go
+++ b/bulk/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {

--- a/composite/batch/README.md
+++ b/composite/batch/README.md
@@ -2,7 +2,7 @@
 [back](../../README.md)
 
 The `batch` package is an implementation of `Salesforce APIs` centered on `Composite Batch` operations.  These operations include:
-* Limits Resources
+* [Limits Resources](./limits/README.md)
 * SObject Resources
 * Query All
 * Query

--- a/composite/batch/limits/README.md
+++ b/composite/batch/limits/README.md
@@ -1,0 +1,29 @@
+# Limits Request API
+[back](../README.md)
+
+The `limits` package provides a `Composite Batch` sub-request implementation
+that is able to fetch organization limit information.
+
+As a reference, see the Salesforce [Limit Resource
+documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm).
+
+```go
+resource, err := batch.NewResource(session)
+if err != nil {
+    fmt.Printf("Batch Composite Error %s\n", err.Error())
+    return
+}
+
+value, err := resource.Retrieve(false, []batch.Subrequester{
+    limits.NewSubrequester(),
+})
+if err != nil {
+    fmt.Printf("Batch Composite Error %s\n", err.Error())
+    return
+}
+
+// value.Results[0] will contain the limit request response;
+// if successful, value.Results[0].Result will be a map[string]interface{}
+// containing the limits as described in the documentation.
+fmt.Printf("%+v\n", value)
+```

--- a/composite/batch/limits/limits.go
+++ b/composite/batch/limits/limits.go
@@ -1,0 +1,54 @@
+// Package limits provides a batch Subrequester that fetches account limit
+// information
+package limits
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/namely/go-sfdc/v3/session"
+)
+
+// LimitRequest provides an batch subrequester that will fetch the current
+// account limits
+type LimitRequest struct {
+	version int
+	sess    session.ServiceFormatter
+}
+
+// NewSubrequester returns a new limit subrequester
+func NewSubrequester(sess session.ServiceFormatter) *LimitRequest {
+	return NewSubrequesterWithVersion(sess, sess.Version())
+}
+
+// NewSubrequesterWithVersion returns a new limit subrequester with a specific
+// API version
+func NewSubrequesterWithVersion(sess session.ServiceFormatter, version int) *LimitRequest {
+	return &LimitRequest{sess: sess, version: version}
+}
+
+// URL returns the URL for the limits request
+func (l *LimitRequest) URL() string {
+	return fmt.Sprintf("/v%d.0/limits", l.version)
+}
+
+// Method returns the HTTP method for the limits request
+func (l *LimitRequest) Method() string {
+	return http.MethodGet
+}
+
+// BinaryPartName fulfills batch.Subrequester; it is unused for limits requests
+func (l *LimitRequest) BinaryPartName() string {
+	return ""
+}
+
+// BinaryPartNameAlias fulfills batch.Subrequester; it is unused for limits
+// requests
+func (l *LimitRequest) BinaryPartNameAlias() string {
+	return ""
+}
+
+// RichInput fulfills batch.Subrequester; it is unused for limits requests
+func (l *LimitRequest) RichInput() map[string]interface{} {
+	return nil
+}

--- a/composite/batch/limits/limits_test.go
+++ b/composite/batch/limits/limits_test.go
@@ -1,0 +1,59 @@
+package limits
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/namely/go-sfdc/v3/session"
+)
+
+type mockSessionFormatter struct {
+	url        string
+	client     *http.Client
+	refreshErr error
+}
+
+func (mock *mockSessionFormatter) ServiceURL() string {
+	return mock.url
+}
+
+func (mock *mockSessionFormatter) Version() int {
+	return 44
+}
+
+func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
+
+func (mock *mockSessionFormatter) Client() *http.Client {
+	return mock.client
+}
+
+func (mock *mockSessionFormatter) InstanceURL() string {
+	return mock.url
+}
+
+func (mock *mockSessionFormatter) Refresh() error {
+	return mock.refreshErr
+}
+
+func TestLimitSubRequestURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		session session.ServiceFormatter
+		expect  string
+	}{
+		{
+			name:    "success",
+			session: &mockSessionFormatter{url: "https://test.salesforce.com/services/data/v44.0"},
+			expect:  "/v44.0/limits",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			limitRequest := NewSubrequester(tt.session)
+			if url := limitRequest.URL(); url != tt.expect {
+				t.Errorf("Subrequester.URL() got %v, expected %v", url, tt.expect)
+			}
+		})
+	}
+}

--- a/composite/batch/mock_session_formatter.go
+++ b/composite/batch/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {

--- a/composite/mock_session_formatter.go
+++ b/composite/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {

--- a/session/session.go
+++ b/session/session.go
@@ -13,6 +13,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	_ ServiceFormatter = &Session{}
+)
+
 // Session is the authentication response.  This is used to generate the
 // authorization header for the Salesforce API calls.
 type Session struct {
@@ -53,6 +57,9 @@ type InstanceFormatter interface {
 // user.
 type ServiceFormatter interface {
 	InstanceFormatter
+	// Version will return the Salesforce API version for this session.
+	Version() int
+	// ServiceURL will return the Salesforce instance for the service URL.
 	ServiceURL() string
 }
 
@@ -143,6 +150,11 @@ func (s *Session) InstanceURL() string {
 	defer s.mu.RUnlock()
 
 	return s.response.InstanceURL
+}
+
+// Version will return the Salesforce API version for this session.
+func (s *Session) Version() int {
+	return s.config.Version
 }
 
 // ServiceURL will return the Salesforce instance for the

--- a/session/session.go
+++ b/session/session.go
@@ -13,14 +13,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	_ ServiceFormatter = &Session{}
-)
-
 // Session is the authentication response.  This is used to generate the
 // authorization header for the Salesforce API calls.
 type Session struct {
-	// tread safe:
+	// thread safe:
 	config sfdc.Configuration
 
 	// thread unsafe:

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSessionIsServiceFormatter(t *testing.T) {
+	var _ ServiceFormatter = &Session{}
+}
+
 func Test_passwordSessionRequest(t *testing.T) {
 	scenarios := []struct {
 		desc  string

--- a/sobject/collections/mock_session_formatter.go
+++ b/sobject/collections/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {

--- a/sobject/mock_session_formatter.go
+++ b/sobject/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {

--- a/sobject/tree/mock_session_formatter.go
+++ b/sobject/tree/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {

--- a/soql/mock_session_formatter.go
+++ b/soql/mock_session_formatter.go
@@ -12,6 +12,10 @@ func (mock *mockSessionFormatter) ServiceURL() string {
 	return mock.url
 }
 
+func (mock *mockSessionFormatter) Version() int {
+	return 42
+}
+
 func (mock *mockSessionFormatter) AuthorizationHeader(*http.Request) {}
 
 func (mock *mockSessionFormatter) Client() *http.Client {


### PR DESCRIPTION
This PR adds a composite batch sub-requester for retrieving Limit information.

I debated adding more structured response handlers (ie, mapping the response to a map of `string` keys to `struct`s w/ `Max` & `Remaining` properties, rather than `map[string]interface{}`), but ultimately decided against it: I think it could be useful, but would/will require more thought about how to extend the `Subrequester` interface.

See #12 for initial inquiry about suitability for inclusion.