### PR TITLE
Use field specific types where possible for Job responses

### DIFF
--- a/bulk/formatter_test.go
+++ b/bulk/formatter_test.go
@@ -22,8 +22,8 @@ func TestNewFormatter(t *testing.T) {
 			args: args{
 				job: &Job{
 					info: Response{
-						ColumnDelimiter: string(Pipe),
-						LineEnding:      string(Linefeed),
+						ColumnDelimiter: Pipe,
+						LineEnding:      Linefeed,
 					},
 				},
 				fields: []string{
@@ -34,8 +34,8 @@ func TestNewFormatter(t *testing.T) {
 			want: &Formatter{
 				job: &Job{
 					info: Response{
-						ColumnDelimiter: string(Pipe),
-						LineEnding:      string(Linefeed),
+						ColumnDelimiter: Pipe,
+						LineEnding:      Linefeed,
 					},
 				},
 				fields: []string{
@@ -63,8 +63,8 @@ func TestNewFormatter(t *testing.T) {
 			args: args{
 				job: &Job{
 					info: Response{
-						ColumnDelimiter: string(Pipe),
-						LineEnding:      string(Linefeed),
+						ColumnDelimiter: Pipe,
+						LineEnding:      Linefeed,
 					},
 				},
 				fields: nil,
@@ -126,8 +126,8 @@ func TestFormatter_Add(t *testing.T) {
 			fields: fields{
 				job: &Job{
 					info: Response{
-						ColumnDelimiter: string(Pipe),
-						LineEnding:      string(Linefeed),
+						ColumnDelimiter: Pipe,
+						LineEnding:      Linefeed,
 					},
 				},
 				fields: []string{
@@ -161,8 +161,8 @@ func TestFormatter_Add(t *testing.T) {
 			fields: fields{
 				job: &Job{
 					info: Response{
-						ColumnDelimiter: string(Pipe),
-						LineEnding:      string(Linefeed),
+						ColumnDelimiter: Pipe,
+						LineEnding:      Linefeed,
 					},
 				},
 				fields: []string{

--- a/bulk/job.go
+++ b/bulk/job.go
@@ -139,21 +139,21 @@ type Options struct {
 
 // Response is the response to job APIs.
 type Response struct {
-	APIVersion          float32 `json:"apiVersion"`
-	ColumnDelimiter     string  `json:"columnDelimiter"`
-	ConcurrencyMode     string  `json:"concurrencyMode"`
-	ContentType         string  `json:"contentType"`
-	ContentURL          string  `json:"contentUrl"`
-	CreatedByID         string  `json:"createdById"`
-	CreatedDate         string  `json:"createdDate"`
-	ExternalIDFieldName string  `json:"externalIdFieldName"`
-	ID                  string  `json:"id"`
-	JobType             string  `json:"jobType"`
-	LineEnding          string  `json:"lineEnding"`
-	Object              string  `json:"object"`
-	Operation           string  `json:"operation"`
-	State               string  `json:"state"`
-	SystemModstamp      string  `json:"systemModstamp"`
+	APIVersion          float32         `json:"apiVersion"`
+	ColumnDelimiter     ColumnDelimiter `json:"columnDelimiter"`
+	ConcurrencyMode     string          `json:"concurrencyMode"`
+	ContentType         string          `json:"contentType"`
+	ContentURL          string          `json:"contentUrl"`
+	CreatedByID         string          `json:"createdById"`
+	CreatedDate         string          `json:"createdDate"`
+	ExternalIDFieldName string          `json:"externalIdFieldName"`
+	ID                  string          `json:"id"`
+	JobType             JobType         `json:"jobType"`
+	LineEnding          LineEnding      `json:"lineEnding"`
+	Object              string          `json:"object"`
+	Operation           Operation       `json:"operation"`
+	State               State           `json:"state"`
+	SystemModstamp      string          `json:"systemModstamp"`
 }
 
 // Info is the response to the job information API.

--- a/bulk/job_test.go
+++ b/bulk/job_test.go
@@ -1238,8 +1238,8 @@ func TestJob_SuccessfulRecords(t *testing.T) {
 			fields: fields{
 				info: Response{
 					ID:              "1234",
-					ColumnDelimiter: string(Pipe),
-					LineEnding:      string(Linefeed),
+					ColumnDelimiter: Pipe,
+					LineEnding:      Linefeed,
 				},
 				session: &mockSessionFormatter{
 					url: "https://test.salesforce.com",
@@ -1338,8 +1338,8 @@ func TestJob_FailedRecords(t *testing.T) {
 			fields: fields{
 				info: Response{
 					ID:              "1234",
-					ColumnDelimiter: string(Pipe),
-					LineEnding:      string(Linefeed),
+					ColumnDelimiter: Pipe,
+					LineEnding:      Linefeed,
 				},
 				session: &mockSessionFormatter{
 					url: "https://test.salesforce.com",
@@ -1436,8 +1436,8 @@ func TestJob_UnprocessedRecords(t *testing.T) {
 			fields: fields{
 				info: Response{
 					ID:              "1234",
-					ColumnDelimiter: string(Pipe),
-					LineEnding:      string(Linefeed),
+					ColumnDelimiter: Pipe,
+					LineEnding:      Linefeed,
 				},
 				session: &mockSessionFormatter{
 					url: "https://test.salesforce.com",


### PR DESCRIPTION
The bulk package defines types and constants for the valid values
of some job info/option fields. This commit updates the Response
struct to use those where possible rather than the plain string
type. This removes the need to type cast during normal operations
(ie, when checking the state of a Job).