### PR TITLE
Return "real" errors from Job related operations.

### DIFF
--- a/error.go
+++ b/error.go
@@ -76,9 +76,9 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 type Errors []Error
 
 func (e Errors) Error() string {
-	msgs := make([]string, len(e))
-	for i, err := range e {
-		msgs[i] = err.Message
+	msgs := make([]string, 0, len(e))
+	for _, err := range e {
+		msgs = append(msgs, err.Error())
 	}
 
 	return strings.Join(msgs, ", ")

--- a/error_test.go
+++ b/error_test.go
@@ -103,7 +103,7 @@ func TestHandleError(t *testing.T) {
 				Status: "400 " + http.StatusText(400),
 				Body:   ioutil.NopCloser(strings.NewReader(singleErrBody)),
 			},
-			wantErr: `400 Bad Request: invalid record id`,
+			wantErr: `400 Bad Request: INVALID_ID_FIELD: invalid record id (id)`,
 			errors: Errors{
 				{
 					Message:   "invalid record id",
@@ -117,7 +117,7 @@ func TestHandleError(t *testing.T) {
 				Status: "400 " + http.StatusText(400),
 				Body:   ioutil.NopCloser(strings.NewReader(multipleErrBody)),
 			},
-			wantErr: `400 Bad Request: invalid record id, invalid record id`,
+			wantErr: `400 Bad Request: INVALID_ID_FIELD: invalid record id (id), INVALID_ID_FIELD: invalid record id (id)`,
 			errors: Errors{
 				{
 					Message:   "invalid record id",

--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,7 @@
 package sfdc
 
 import (
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -95,21 +96,40 @@ func TestHandleError(t *testing.T) {
 	tests := map[string]struct {
 		resp    *http.Response
 		wantErr string
+		errors  Errors
 	}{
 		"single_error": {
 			resp: &http.Response{
 				Status: "400 " + http.StatusText(400),
 				Body:   ioutil.NopCloser(strings.NewReader(singleErrBody)),
 			},
-			wantErr: `400 Bad Request: ` + singleErrBody,
+			wantErr: `400 Bad Request: invalid record id`,
+			errors: Errors{
+				{
+					Message:   "invalid record id",
+					ErrorCode: "INVALID_ID_FIELD",
+					Fields:    []string{"id"},
+				},
+			},
 		},
-		// TODO(vtopc): remove next case if SF API is never sending multiple errors:
 		"multiple_error": {
 			resp: &http.Response{
 				Status: "400 " + http.StatusText(400),
 				Body:   ioutil.NopCloser(strings.NewReader(multipleErrBody)),
 			},
-			wantErr: `400 Bad Request: ` + multipleErrBody,
+			wantErr: `400 Bad Request: invalid record id, invalid record id`,
+			errors: Errors{
+				{
+					Message:   "invalid record id",
+					ErrorCode: "INVALID_ID_FIELD",
+					Fields:    []string{"id"},
+				},
+				{
+					Message:   "invalid record id",
+					ErrorCode: "INVALID_ID_FIELD",
+					Fields:    []string{"id"},
+				},
+			},
 		},
 		"read_body_error": {
 			resp: &http.Response{
@@ -125,6 +145,12 @@ func TestHandleError(t *testing.T) {
 			err := HandleError(tt.resp)
 			t.Log("err:", err)
 			require.EqualError(t, err, tt.wantErr)
+
+			if tt.errors != nil {
+				sfdcErr := Errors{}
+				require.True(t, errors.As(err, &sfdcErr))
+				require.Equal(t, tt.errors, sfdcErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I've recently run into a case where I want to abort Bulk jobs and inspect the error response if I'm unable to. The current error wrapping doesn't seem very helpful: if there's more than one error, we only get the last one back.

The PR makes `sfdc.Error` into a "real" Go error that can be returned directly, while also defining a convenience type for returning a collection of errors from a response. By returning the actual sfdc.Error object, we're able to inspect the error code in the caller to determine the best coarse of action.

I'm creating this as a draft PR because I'm not sure how this fits with your vision for `HandleError`, which I seem to recall you've been moving toward. Any feedback is welcome!
